### PR TITLE
fix(ui): content layout shift by discord user

### DIFF
--- a/public/lanyard.js
+++ b/public/lanyard.js
@@ -98,6 +98,10 @@ window.addEventListener("load", () => {
 
             const discrimBox = document.getElementById('discordDiscrim');
             discrimBox.innerText = '#' + presenceData.discord_user.discriminator;
+
+            const discordTagBox = document.getElementById('discordUserBox');
+            discordTagBox.classList.add('opacity-100');
+            discordTagBox.classList.remove('opacity-0');
         },
     });
 });

--- a/src/components/HomeHero/index.tsx
+++ b/src/components/HomeHero/index.tsx
@@ -5,8 +5,10 @@ export default function HomeHero() {
 		<div className={styles.homeHeroWrapper}>
 			<div className={styles.heroContent}>
 				<div className={styles.heroContentInner}>
-					<img src="/pfp.png" alt="My profile pic" className="w-56 md:w-80 h-56 md:h-80 rounded-full" />
-					<div className="flex flex-col items-center md:items-start mt-8 md:mt-0 md:ml-8">
+					<div className="flex-1 flex justify-end">
+						<img src="/pfp.png" alt="My profile pic" className="w-56 md:w-80 h-56 md:h-80 rounded-full" />
+					</div>
+					<div className="flex flex-col flex-1 md:items-start mt-8 md:mt-0 md:ml-8">
 						<h1 className="flex text-6xl md:text-8xl font-display text-center md:text-left items-start">
 							Liz Ainslie
 							<div id='discordBox' className={styles.discordTag}>
@@ -25,8 +27,10 @@ export default function HomeHero() {
 									<circle cx="9" cy="12" r="1" />
 									<circle cx="15" cy="12" r="1" />
 								</svg>
-								<span id='discordUsername'></span>
-								<span className={styles.discrim} id='discordDiscrim'></span>
+								<div className="opacity-0 transition-opacity duration-300" id='discordUserBox'>
+									<span id='discordUsername'></span>
+									<span className={styles.discrim} id='discordDiscrim'></span>
+								</div>
 							</div>
 						</h1>
 						<p className="text-3xl text-center md:text-left mt-4 md:mt-0">Freelance & Hobbyist Full Stack Developer</p>

--- a/src/components/HomeHero/index.tsx
+++ b/src/components/HomeHero/index.tsx
@@ -27,7 +27,7 @@ export default function HomeHero() {
 									<circle cx="9" cy="12" r="1" />
 									<circle cx="15" cy="12" r="1" />
 								</svg>
-								<div className="opacity-0 transition-opacity duration-300" id='discordUserBox'>
+								<div className="opacity-0 transition-opacity duration-300 whitespace-nowrap" id='discordUserBox'>
 									<span id='discordUsername'></span>
 									<span className={styles.discrim} id='discordDiscrim'></span>
 								</div>

--- a/src/components/HomeHero/styles.module.scss
+++ b/src/components/HomeHero/styles.module.scss
@@ -7,7 +7,7 @@
 		z-index: 200;
 
 		.heroContentInner {
-			@apply flex items-center flex-col md:flex-row p-2 md:p-0;
+			@apply flex items-center w-full justify-center md:flex-row p-2 md:p-0;
 		}
 
 		.discordTag {


### PR DESCRIPTION
Resolves issue #4 

I basically did the center div to have full width, so the right part could have the full remaining space, so when the discord box updates it doesn't cause the layout shift.
It's not perfect but I think that solves the problem. Also, I added a little opacity transition when it hydrate the box. What do you think?